### PR TITLE
Fix typo in Package Activation Panel

### DIFF
--- a/lib/timecop-view.coffee
+++ b/lib/timecop-view.coffee
@@ -55,7 +55,7 @@ class TimecopView extends ScrollView
     @packageActivationPanel.addPackages(packages, 'activateTime')
     @packageActivationPanel.summary.text """
       Activated #{count} packages in #{time}ms.
-      #{_.pluralize(packages.lenght, 'package')} took longer than 5ms to activate.
+      #{_.pluralize(packages.length, 'package')} took longer than 5ms to activate.
     """
 
   showLoadedThemes: ->


### PR DESCRIPTION
The number of activated packages, which took longer than 5ms to activate,
is now displayed correctly.

Before:
![screen shot 2014-03-04 at 16 12 39](https://f.cloud.github.com/assets/256075/2322467/a3f08100-a3b1-11e3-8f71-a98694a7158c.png)

After:
![screen shot 2014-03-04 at 16 27 21](https://f.cloud.github.com/assets/256075/2322468/a89b2a3e-a3b1-11e3-9777-88e058233383.png)
