### PR TITLE
Rename 6to5 to Babel.

### DIFF
--- a/lib/cache-panel-view.coffee
+++ b/lib/cache-panel-view.coffee
@@ -13,8 +13,8 @@ class CachePanelView extends View
             @span class: 'inline-block highlight-info', outlet: 'coffeeCompileCount'
 
           @div class: 'timing', =>
-            @span class: 'inline-block', '6to5 files compiled'
-            @span class: 'inline-block highlight-info', outlet: 'to5CompileCount'
+            @span class: 'inline-block', 'Babel files compiled'
+            @span class: 'inline-block highlight-info', outlet: 'babelCompileCount'
 
           @div class: 'timing', =>
             @span class: 'inline-block', 'CSON files compiled'
@@ -29,7 +29,7 @@ class CachePanelView extends View
 
   populate: ->
     @coffeeCompileCount.text(@getCoffeeCompiles())
-    @to5CompileCount.text(@get6to5Compiles())
+    @babelCompileCount.text(@getBabelCompiles())
     @csonCompileCount.text(@getCsonCompiles())
     @lessCompileCount.text(@getLessCompiles())
 
@@ -40,11 +40,11 @@ class CachePanelView extends View
       cacheMisses = CoffeeCache.getCacheMisses?() ? 0
     cacheMisses
 
-  get6to5Compiles: ->
+  getBabelCompiles: ->
     cacheMisses = 0
     try
-      To5Cache = require(path.join(atom.getLoadSettings().resourcePath, 'src', '6to5'))
-      cacheMisses = To5Cache.getCacheMisses?() ? 0
+      babelCache = require(path.join(atom.getLoadSettings().resourcePath, 'src', 'babel'))
+      cacheMisses = babelCache.getCacheMisses?() ? 0
     cacheMisses
 
   getCsonCompiles: ->


### PR DESCRIPTION
Updated to reflect the changes introduced in
https://github.com/atom/atom/commit/caff9e08663e669759a64cb725d9571e894558f9