### PR TITLE
Fix typo in tooltip

### DIFF
--- a/lib/window-panel-view.coffee
+++ b/lib/window-panel-view.coffee
@@ -31,7 +31,7 @@ class WindowPanelView extends View
   initialize: ->
     atom.tooltips.add(@windowTiming[0], title: 'The time taken to load this window')
     atom.tooltips.add(@shellTiming[0], title: 'The time taken to launch the app')
-    atom.tooltips.add(@workspaceTiming[0], title: 'The time taken to rebuild the prevoiusly opened editors')
+    atom.tooltips.add(@workspaceTiming[0], title: 'The time taken to rebuild the previously opened editors')
     atom.tooltips.add(@projectTiming[0], title: 'The time taken to rebuild the previously opened buffers')
     atom.tooltips.add(@atomTiming[0], title: 'The time taken to read and parse the stored window state')
 


### PR DESCRIPTION
<img src="https://cloud.githubusercontent.com/assets/2346707/16650128/cfc72e48-447f-11e6-9327-415e407fe118.png" width="575" alt="﹥prevoiusly" />

⸻ From your friendly neighbourhood Typocop
