### PR TITLE
Show 'NA' for non-available times; Fixes #24

### DIFF
--- a/lib/package-panel-view.js
+++ b/lib/package-panel-view.js
@@ -62,7 +62,7 @@ export default class PackagePanelView {
 
     const timeSpan = document.createElement('span')
     timeSpan.classList.add('inline-block', pack[timeKey] > 25 ? 'highlight-error' : 'highlight-warning')
-    timeSpan.textContent = `${pack[timeKey]}ms`
+    timeSpan.textContent = pack[timeKey] != null ? `${pack[timeKey]}ms` : 'NA'
     li.appendChild(timeSpan)
 
     this.refs.list.appendChild(li)

--- a/lib/window-panel-view.js
+++ b/lib/window-panel-view.js
@@ -64,7 +64,7 @@ export default class WindowPanelView {
   populate () {
     const time = atom.getWindowLoadTime()
     this.refs.windowLoadTime.classList.add(this.getHighlightClass(time))
-    this.refs.windowLoadTime.textContent = `${time}ms`
+    this.refs.windowLoadTime.textContent = time != null ? `${time}ms` : 'NA'
 
     const {shellLoadTime} = atom.getLoadSettings()
     if (shellLoadTime != null) {
@@ -76,11 +76,11 @@ export default class WindowPanelView {
 
     if (atom.deserializeTimings != null) {
       this.refs.workspaceLoadTime.classList.add(this.getHighlightClass(atom.deserializeTimings.workspace))
-      this.refs.workspaceLoadTime.textContent = `${atom.deserializeTimings.workspace}ms`
+      this.refs.workspaceLoadTime.textContent = atom.deserializeTimings.workspace != null ? `${atom.deserializeTimings.workspace}ms` : 'NA'
       this.refs.projectLoadTime.classList.add(this.getHighlightClass(atom.deserializeTimings.project))
-      this.refs.projectLoadTime.textContent = `${atom.deserializeTimings.project}ms`
+      this.refs.projectLoadTime.textContent = atom.deserializeTimings.project != null ? `${atom.deserializeTimings.project}ms` : 'NA'
       this.refs.atomLoadTime.classList.add(this.getHighlightClass(atom.deserializeTimings.atom))
-      this.refs.atomLoadTime.textContent = `${atom.deserializeTimings.atom}ms`
+      this.refs.atomLoadTime.textContent = atom.deserializeTimings.atom != null ? `${atom.deserializeTimings.atom}ms` : 'NA'
     } else {
       this.refs.deserializeTimings.style.display = 'none'
     }


### PR DESCRIPTION
![atom-timecop-before](https://cloud.githubusercontent.com/assets/1192669/25589880/1cec8a2e-2e63-11e7-8e73-9252f133e47f.png)

![atom-timecop-after](https://cloud.githubusercontent.com/assets/1192669/25589881/1cf1492e-2e63-11e7-999f-49c84daeba16.png)

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

When the times are not available, they are shown as 'undefinedms'. This change is to display 'NA' for non-available times.

### Alternate Designs

None

### Benefits

'NA' is more descriptive/helpful than 'undefinedms'.

### Possible Drawbacks

None

### Applicable Issues

None
