### PR TITLE
Dispose of subscriptions properly when deactivating

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,13 +1,20 @@
+const {CompositeDisposable} = require('atom')
+
 let TimecopView = null
 const ViewURI = 'atom://timecop'
 
 module.exports = {
   activate () {
-    atom.workspace.addOpener(filePath => {
+    this.subscriptions = new CompositeDisposable()
+    this.subscriptions.add(atom.workspace.addOpener(filePath => {
       if (filePath === ViewURI) return this.createTimecopView({uri: ViewURI})
-    })
+    }))
 
-    atom.commands.add('atom-workspace', 'timecop:view', () => atom.workspace.open(ViewURI))
+    this.subscriptions.add(atom.commands.add('atom-workspace', 'timecop:view', () => atom.workspace.open(ViewURI)))
+  },
+
+  deactivate () {
+    this.subscriptions.dispose()
   },
 
   createTimecopView (state) {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Like previous PRs in other repos, this PR makes sure that all subscriptions are disposed when Timecop is deactivated.  This ensures that the Command Palette stays uncluttered and that multiple Timecops are not created when repeatedly disabled and re-enabled.

### Alternate Designs

None.

### Benefits

Correct package deactivation.

### Possible Drawbacks

None.

### Applicable Issues

None.