### PR TITLE
Cleanup

### DIFF
--- a/lib/cache-panel-view.js
+++ b/lib/cache-panel-view.js
@@ -23,27 +23,27 @@ export default class CachePanelView {
           <div className='panel-body padded'>
             <div className='timing'>
               <span className='inline-block'>CoffeeScript files compiled</span>
-              <span className='inline-block highlight-info' ref='coffeeCompileCount'>0</span>
+              <span className='inline-block' ref='coffeeCompileCount'>Loading…</span>
             </div>
 
             <div className='timing'>
               <span className='inline-block'>Babel files compiled</span>
-              <span className='inline-block highlight-info' ref='babelCompileCount' />
+              <span className='inline-block' ref='babelCompileCount'>Loading…</span>
             </div>
 
             <div className='timing'>
               <span className='inline-block'>Typescript files compiled</span>
-              <span className='inline-block highlight-info' ref='typescriptCompileCount' />
+              <span className='inline-block' ref='typescriptCompileCount'>Loading…</span>
             </div>
 
             <div className='timing'>
               <span className='inline-block'>CSON files compiled</span>
-              <span className='inline-block highlight-info' ref='csonCompileCount' />
+              <span className='inline-block' ref='csonCompileCount'>Loading…</span>
             </div>
 
             <div className='timing'>
               <span className='inline-block'>Less files compiled</span>
-              <span className='inline-block highlight-info' ref='lessCompileCount' />
+              <span className='inline-block' ref='lessCompileCount'>Loading…</span>
             </div>
           </div>
         </div>
@@ -54,12 +54,17 @@ export default class CachePanelView {
   populate () {
     const compileCacheStats = this.getCompileCacheStats()
     if (compileCacheStats) {
+      this.refs.coffeeCompileCount.classList.add('highlight-info')
       this.refs.coffeeCompileCount.textContent = compileCacheStats['.coffee'].misses
+      this.refs.babelCompileCount.classList.add('highlight-info')
       this.refs.babelCompileCount.textContent = compileCacheStats['.js'].misses
+      this.refs.typescriptCompileCount.classList.add('highlight-info')
       this.refs.typescriptCompileCount.textContent = compileCacheStats['.ts'].misses
     }
 
+    this.refs.csonCompileCount.classList.add('highlight-info')
     this.refs.csonCompileCount.textContent = this.getCsonCompiles()
+    this.refs.lessCompileCount.classList.add('highlight-info')
     this.refs.lessCompileCount.textContent = this.getLessCompiles()
   }
 

--- a/lib/package-panel-view.js
+++ b/lib/package-panel-view.js
@@ -32,7 +32,7 @@ export default class PackagePanelView {
         <div className='inset-panel'>
           <div className='panel-heading'>{this.title}</div>
           <div className='panel-body padded'>
-            <div className='text-info' ref='summary' />
+            <div className='text-info' ref='summary'>Loading…</div>
             <ul className='list-group' ref='list' />
           </div>
         </div>

--- a/lib/timecop-view.js
+++ b/lib/timecop-view.js
@@ -3,7 +3,6 @@
 
 import _ from 'underscore-plus'
 import dedent from 'dedent'
-import {Disposable} from 'atom'
 import etch from 'etch'
 import CachePanelView from './cache-panel-view'
 import PackagePanelView from './package-panel-view'
@@ -126,13 +125,5 @@ export default class TimecopView {
 
   getIconName () {
     return 'dashboard'
-  }
-
-  onDidChangeTitle () {
-    return new Disposable(function () {})
-  }
-
-  onDidChangeModified () {
-    return new Disposable(function () {})
   }
 }

--- a/lib/timecop-view.js
+++ b/lib/timecop-view.js
@@ -12,11 +12,10 @@ export default class TimecopView {
   constructor ({uri}) {
     this.uri = uri
     etch.initialize(this)
-    if (atom.packages.getActivePackages().length > 0) {
+    if (atom.packages.hasActivatedInitialPackages()) {
       this.populateViews()
     } else {
-      // Render on next tick so packages have been activated
-      setImmediate(() => { this.populateViews() })
+      atom.packages.onDidActivateInitialPackages(() => this.populateViews())
     }
   }
 

--- a/lib/window-panel-view.js
+++ b/lib/window-panel-view.js
@@ -31,28 +31,28 @@ export default class WindowPanelView {
           <div className='panel-body padded'>
             <div className='timing' ref='windowTiming'>
               <span className='inline-block'>Window load time</span>
-              <span className='inline-block' ref='windowLoadTime' />
+              <span className='inline-block' ref='windowLoadTime'>Loading…</span>
             </div>
 
             <div className='timing' ref='shellTiming'>
               <span className='inline-block'>Shell load time</span>
-              <span className='inline-block' ref='shellLoadTime' />
+              <span className='inline-block' ref='shellLoadTime'>Loading…</span>
             </div>
 
             <div ref='deserializeTimings'>
               <div className='timing' ref='workspaceTiming'>
                 <span className='inline-block'>Workspace load time</span>
-                <span className='inline-block' ref='workspaceLoadTime' />
+                <span className='inline-block' ref='workspaceLoadTime'>Loading…</span>
               </div>
 
               <div className='timing' ref='projectTiming'>
                 <span className='inline-block'>Project load time</span>
-                <span className='inline-block' ref='projectLoadTime' />
+                <span className='inline-block' ref='projectLoadTime'>Loading…</span>
               </div>
 
               <div className='timing' ref='atomTiming'>
                 <span className='inline-block'>Window state load time</span>
-                <span className='inline-block' ref='atomLoadTime' />
+                <span className='inline-block' ref='atomLoadTime'>Loading…</span>
               </div>
             </div>
           </div>

--- a/spec/timecop-spec.js
+++ b/spec/timecop-spec.js
@@ -53,6 +53,7 @@ describe('Timecop', () => {
 
       spyOn(atom.packages, 'getLoadedPackages').andReturn(packages)
       spyOn(atom.packages, 'getActivePackages').andReturn(packages)
+      spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true)
 
       timecopView = await atom.workspace.open('atom://timecop')
     })


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Use `atom.packages.hasActivatedInitialPackages()` (and the relevant hook) to determine when to populate the Timecop view
  * Show `Loading…` before packages have finished activating
  * Prevents Timecop from improperly showing only a few packages activated due to the `process.nextTick` call
* Remove optional Workspace methods in TimecopView that were just stubs

### Alternate Designs

I noticed that there was also an `atom.packages.hasLoadedInitialPackages`.  I'm going to experiment with that to see if we can use that to split up the view loading.

### Benefits

Code savings and more accurate Timecop view

### Possible Drawbacks

None.

### Applicable Issues

None.