### PR TITLE
Only show project load times when a project is deserialized

### DIFF
--- a/lib/window-panel-view.js
+++ b/lib/window-panel-view.js
@@ -9,11 +9,11 @@ export default class WindowPanelView {
     etch.initialize(this)
 
     this.disposables = new CompositeDisposable()
-    this.disposables.add(atom.tooltips.add(this.refs.windowTiming, {title: 'The time taken to load this window'}))
     this.disposables.add(atom.tooltips.add(this.refs.shellTiming, {title: 'The time taken to launch the app'}))
-    this.disposables.add(atom.tooltips.add(this.refs.workspaceTiming, {title: 'The time taken to rebuild the previously opened editors'}))
-    this.disposables.add(atom.tooltips.add(this.refs.projectTiming, {title: 'The time taken to rebuild the previously opened buffers'}))
+    this.disposables.add(atom.tooltips.add(this.refs.windowTiming, {title: 'The time taken to load this window'}))
     this.disposables.add(atom.tooltips.add(this.refs.atomTiming, {title: 'The time taken to read and parse the stored window state'}))
+    this.disposables.add(atom.tooltips.add(this.refs.projectTiming, {title: 'The time taken to rebuild the previously opened buffers'}))
+    this.disposables.add(atom.tooltips.add(this.refs.workspaceTiming, {title: 'The time taken to rebuild the previously opened editors'}))
   }
 
   update () {}
@@ -29,30 +29,30 @@ export default class WindowPanelView {
         <div className='inset-panel'>
           <div className='panel-heading'>Startup Time</div>
           <div className='panel-body padded'>
-            <div className='timing' ref='windowTiming'>
-              <span className='inline-block'>Window load time</span>
-              <span className='inline-block' ref='windowLoadTime'>Loading…</span>
-            </div>
-
             <div className='timing' ref='shellTiming'>
               <span className='inline-block'>Shell load time</span>
               <span className='inline-block' ref='shellLoadTime'>Loading…</span>
             </div>
 
-            <div ref='deserializeTimings'>
-              <div className='timing' ref='workspaceTiming'>
-                <span className='inline-block'>Workspace load time</span>
-                <span className='inline-block' ref='workspaceLoadTime'>Loading…</span>
-              </div>
+            <div className='timing' ref='windowTiming'>
+              <span className='inline-block'>Window load time</span>
+              <span className='inline-block' ref='windowLoadTime'>Loading…</span>
+            </div>
 
+            <div className='timing' ref='atomTiming'>
+              <span className='inline-block'>Window state load time</span>
+              <span className='inline-block' ref='atomLoadTime'>Loading…</span>
+            </div>
+
+            <div ref='deserializeTimings'>
               <div className='timing' ref='projectTiming'>
                 <span className='inline-block'>Project load time</span>
                 <span className='inline-block' ref='projectLoadTime'>Loading…</span>
               </div>
 
-              <div className='timing' ref='atomTiming'>
-                <span className='inline-block'>Window state load time</span>
-                <span className='inline-block' ref='atomLoadTime'>Loading…</span>
+              <div className='timing' ref='workspaceTiming'>
+                <span className='inline-block'>Workspace load time</span>
+                <span className='inline-block' ref='workspaceLoadTime'>Loading…</span>
               </div>
             </div>
           </div>
@@ -74,13 +74,15 @@ export default class WindowPanelView {
       this.refs.shellTiming.style.display = 'none'
     }
 
-    if (atom.deserializeTimings != null) {
-      this.refs.workspaceLoadTime.classList.add(this.getHighlightClass(atom.deserializeTimings.workspace))
-      this.refs.workspaceLoadTime.textContent = `${atom.deserializeTimings.workspace}ms`
+    this.refs.atomLoadTime.classList.add(this.getHighlightClass(atom.deserializeTimings.atom))
+    this.refs.atomLoadTime.textContent = `${atom.deserializeTimings.atom}ms`
+
+    if (atom.deserializeTimings.project != null) {
+      // Project and workspace timings only exist if the current project was previously opened
       this.refs.projectLoadTime.classList.add(this.getHighlightClass(atom.deserializeTimings.project))
       this.refs.projectLoadTime.textContent = `${atom.deserializeTimings.project}ms`
-      this.refs.atomLoadTime.classList.add(this.getHighlightClass(atom.deserializeTimings.atom))
-      this.refs.atomLoadTime.textContent = `${atom.deserializeTimings.atom}ms`
+      this.refs.workspaceLoadTime.classList.add(this.getHighlightClass(atom.deserializeTimings.workspace))
+      this.refs.workspaceLoadTime.textContent = `${atom.deserializeTimings.workspace}ms`
     } else {
       this.refs.deserializeTimings.style.display = 'none'
     }

--- a/lib/window-panel-view.js
+++ b/lib/window-panel-view.js
@@ -11,7 +11,6 @@ export default class WindowPanelView {
     this.disposables = new CompositeDisposable()
     this.disposables.add(atom.tooltips.add(this.refs.shellTiming, {title: 'The time taken to launch the app'}))
     this.disposables.add(atom.tooltips.add(this.refs.windowTiming, {title: 'The time taken to load this window'}))
-    this.disposables.add(atom.tooltips.add(this.refs.atomTiming, {title: 'The time taken to read and parse the stored window state'}))
     this.disposables.add(atom.tooltips.add(this.refs.projectTiming, {title: 'The time taken to rebuild the previously opened buffers'}))
     this.disposables.add(atom.tooltips.add(this.refs.workspaceTiming, {title: 'The time taken to rebuild the previously opened editors'}))
   }
@@ -37,11 +36,6 @@ export default class WindowPanelView {
             <div className='timing' ref='windowTiming'>
               <span className='inline-block'>Window load time</span>
               <span className='inline-block' ref='windowLoadTime'>Loading…</span>
-            </div>
-
-            <div className='timing' ref='atomTiming'>
-              <span className='inline-block'>Window state load time</span>
-              <span className='inline-block' ref='atomLoadTime'>Loading…</span>
             </div>
 
             <div ref='deserializeTimings'>
@@ -73,9 +67,6 @@ export default class WindowPanelView {
     } else {
       this.refs.shellTiming.style.display = 'none'
     }
-
-    this.refs.atomLoadTime.classList.add(this.getHighlightClass(atom.deserializeTimings.atom))
-    this.refs.atomLoadTime.textContent = `${atom.deserializeTimings.atom}ms`
 
     if (atom.deserializeTimings.project != null) {
       // Project and workspace timings only exist if the current project was previously opened

--- a/spec/timecop-spec.js
+++ b/spec/timecop-spec.js
@@ -5,12 +5,7 @@ const CSON = require(path.join(atom.getLoadSettings().resourcePath, 'node_module
 const {it, fit, ffit, beforeEach, afterEach} = require('./async-spec-helpers') // eslint-disable-line no-unused-vars
 
 describe('Timecop', () => {
-  let workspaceElement = null
-
   beforeEach(async () => {
-    workspaceElement = atom.views.getView(atom.workspace)
-    jasmine.attachToDOM(workspaceElement)
-
     spyOn(CompileCache, 'getCacheStats').andReturn({
       '.js': {hits: 3, misses: 4},
       '.ts': {hits: 5, misses: 6},


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This prevents project and workspace load times from showing up as `undefinedms`.  In addition, I have removed the window state load time as it was just the project load time and the workspace load time added together (and 0 when there was no project to load).  Finally, the display order has been changed to better follow the logical load order:
* Shell
* Window
* Project
* Workspace

### Alternate Designs

None.

### Benefits

More logical display order and hiding of project + workspace times when there is no previous state.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #24
Fixes #19