### PR TITLE
Also use onDidLoadInitialPackages hook

### DIFF
--- a/lib/timecop-view.js
+++ b/lib/timecop-view.js
@@ -12,10 +12,17 @@ export default class TimecopView {
   constructor ({uri}) {
     this.uri = uri
     etch.initialize(this)
-    if (atom.packages.hasActivatedInitialPackages()) {
-      this.populateViews()
+    this.refs.cacheLoadingPanel.populate()
+    if (atom.packages.hasLoadedInitialPackages()) {
+      this.populateLoadingViews()
     } else {
-      atom.packages.onDidActivateInitialPackages(() => this.populateViews())
+      atom.packages.onDidLoadInitialPackages(() => this.populateLoadingViews())
+    }
+
+    if (atom.packages.hasActivatedInitialPackages()) {
+      this.populateActivationViews()
+    } else {
+      atom.packages.onDidActivateInitialPackages(() => this.populateActivationViews())
     }
   }
 
@@ -44,12 +51,14 @@ export default class TimecopView {
     )
   }
 
-  populateViews () {
-    this.refs.windowLoadingPanel.populate()
-    this.refs.cacheLoadingPanel.populate()
+  populateLoadingViews () {
     this.showLoadedPackages()
-    this.showActivePackages()
     this.showLoadedThemes()
+  }
+
+  populateActivationViews () {
+    this.refs.windowLoadingPanel.populate()
+    this.showActivePackages()
     this.showActiveThemes()
   }
 

--- a/spec/timecop-spec.js
+++ b/spec/timecop-spec.js
@@ -48,6 +48,7 @@ describe('Timecop', () => {
 
       spyOn(atom.packages, 'getLoadedPackages').andReturn(packages)
       spyOn(atom.packages, 'getActivePackages').andReturn(packages)
+      spyOn(atom.packages, 'hasLoadedInitialPackages').andReturn(true)
       spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true)
 
       timecopView = await atom.workspace.open('atom://timecop')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Allows selective displaying of panels based on how far Atom has loaded.  At initial load, the cache panel can be shown.  When initial packages are loaded, the package and theme load panels can be shown.  Finally, when initial packages are activated, the package and theme activation panels and window load panels can be shown.

### Alternate Designs

None.

### Benefits

Faster UI feedback when the Timecop view is open when Atom starts.

### Possible Drawbacks

None.

### Applicable Issues

None.